### PR TITLE
Improve Automation

### DIFF
--- a/CreateSurfaceWindowsImage.ps1
+++ b/CreateSurfaceWindowsImage.ps1
@@ -811,6 +811,7 @@ Function Download-LatestUpdates
             $downloaddialog = $downloaddialog.Replace('www.download.windowsupdate', 'download.windowsupdate')
             $DLWUDOTCOM = ($downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://download\.windowsupdate\.com\/[^\'\""]*)" | Select-Object -Unique | ForEach-Object { [PSCustomObject] @{ Source = $_.matches.value } } ).source
             $DLDELDOTCOM = ($downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://dl\.delivery\.mp\.microsoft\.com\/[^\'\""]*)" | Select-Object -Unique | ForEach-Object { [PSCustomObject] @{ Source = $_.matches.value } } ).source
+            $DLCATWUDOTCOM = ($downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://catalog\.s\.download\.windowsupdate\.com\/[^\'\""]*)" | Select-Object -Unique | ForEach-Object { [PSCustomObject] @{ Source = $_.matches.value } }).source
 
             If ($DLWUDOTCOM)
             {
@@ -820,6 +821,11 @@ Function Download-LatestUpdates
             {
                 $links = $DLDELDOTCOM
             }
+            If ($DLCATWUDOTCOM)
+            {
+                $links = $DLCATWUDOTCOM
+            }
+            
 
             If ($links)
             {

--- a/CreateSurfaceWindowsImage.ps1
+++ b/CreateSurfaceWindowsImage.ps1
@@ -247,7 +247,7 @@ Param(
         Mandatory=$False,
         HelpMessage="keep automation, default is true)"
         )]
-        [bool]$Automated = $True,
+        [bool]$Automated = $True
     )
 
 

--- a/CreateSurfaceWindowsImage.ps1
+++ b/CreateSurfaceWindowsImage.ps1
@@ -815,7 +815,6 @@ Function Download-LatestUpdates
             $downloaddialog = $downloaddialog.Replace('www.download.windowsupdate', 'download.windowsupdate')
             $DLWUDOTCOM = ($downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://download\.windowsupdate\.com\/[^\'\""]*)" | Select-Object -Unique | ForEach-Object { [PSCustomObject] @{ Source = $_.matches.value } } ).source
             $DLDELDOTCOM = ($downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://dl\.delivery\.mp\.microsoft\.com\/[^\'\""]*)" | Select-Object -Unique | ForEach-Object { [PSCustomObject] @{ Source = $_.matches.value } } ).source
-            $DLCATWUDOTCOM = ($downloaddialog | Select-String -AllMatches -Pattern "(http[s]?\://catalog\.s\.download\.windowsupdate\.com\/[^\'\""]*)" | Select-Object -Unique | ForEach-Object { [PSCustomObject] @{ Source = $_.matches.value } }).source
 
             If ($DLWUDOTCOM)
             {
@@ -825,11 +824,6 @@ Function Download-LatestUpdates
             {
                 $links = $DLDELDOTCOM
             }
-            If ($DLCATWUDOTCOM)
-            {
-                $links = $DLCATWUDOTCOM
-            }
-            
 
             If ($links)
             {

--- a/CreateSurfaceWindowsImage.ps1
+++ b/CreateSurfaceWindowsImage.ps1
@@ -240,7 +240,14 @@ Param(
         Mandatory=$False,
         HelpMessage="Path to an MSI or extracted driver folder - required if you set UseLocalDriverPath variable to true or script will not find any drivers to inject"
         )]
-        [string]$LocalDriverPath
+        [string]$LocalDriverPath,
+
+    [Parameter(
+        Position=22,
+        Mandatory=$False,
+        HelpMessage="keep automation, default is true)"
+        )]
+        [bool]$Automated = $True,
     )
 
 
@@ -3560,6 +3567,7 @@ If ($UseLocalDriverPath -eq $True)
 {
     Write-Output "  Use Local driver path:      $LocalDriverPath" | Receive-Output -Color White -LogLevel 1 -LineNumber "$($Invocation.MyCommand.Name):$( & {$MyInvocation.ScriptLineNumber})"
 }
+Write-Output "  Automated:                  $Automated" | Receive-Output -Color White -LogLevel 1 -LineNumber "$($Invocation.MyCommand.Name):$( & {$MyInvocation.ScriptLineNumber})"
 Write-Output "  Create USB key:             $CreateUSB" | Receive-Output -Color White -LogLevel 1 -LineNumber "$($Invocation.MyCommand.Name):$( & {$MyInvocation.ScriptLineNumber})"
 Write-Output "  Create ISO:                 $CreateISO" | Receive-Output -Color White -LogLevel 1 -LineNumber "$($Invocation.MyCommand.Name):$( & {$MyInvocation.ScriptLineNumber})"
 Write-Output " " | Receive-Output -Color White -LogLevel 1 -LineNumber "$($Invocation.MyCommand.Name):$( & {$MyInvocation.ScriptLineNumber})"
@@ -3661,35 +3669,51 @@ If ($ServicingStack -eq $True)
     Get-ServicingStackUpdates -TempFolder $TempFolder
 }
 
-PAUSE
+If (!($Automated))
+{
+    PAUSE
+}
+
 
 If ($CumulativeUpdate -eq $True)
 {
     Get-CumulativeUpdates -TempFolder $TempFolder
 }
 
-PAUSE
+If (!($Automated))
+{
+    PAUSE
+}
 
 If ($DotNet35 -eq $True)
 {
     Get-CumulativeDotNetUpdates -TempFolder $TempFolder
 }
 
-PAUSE
+If (!($Automated))
+{
+    PAUSE
+}
 
 If ($AdobeFlashUpdate -eq $True)
 {
 	Get-AdobeFlashUpdates -TempFolder $TempFolder
 }
 
-PAUSE
+If (!($Automated))
+{
+    PAUSE
+}
 
 If ($OOBUpdate -eq $True)
 {
 	Get-OOBUpdates -TempFolder $TempFolder
 }
 
-PAUSE
+If (!($Automated))
+{
+    PAUSE
+}
 
 
 # Add Servicing Stack / Cumulative updates and necessary drivers to install.wim, winre.wim, and boot.wim

--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ The parameters that are supported to configure for the script are as follows:
  -UseLocalDriverPath          Use a local driver path and skip downloading the latest MSI for Device, True or False.  False is default.  If this parameter is set, you must also set LocalDriverPath to a valid path containing the extracted drivers you wish to inject, or this will fail.
 
  -LocalDriverPath             Filesystem (accessible to this PowerShell instance) path containing drivers to use.  Only read if UseLocalDriverPath is set to True.
+
+ -Automated                   Keep the scripts automated, if set to true scripts won't pause. True or False.  True is default.


### PR DESCRIPTION
Currently Pause Statements in CreateSurfaceWindowsImage.ps1 prevent automation to create .ISO files.
Fixing that by using a switch to control if the user wants automation or not. 
