### PR TITLE
Update CreateSurfaceWindowsImage.ps1

### DIFF
--- a/CreateSurfaceWindowsImage.ps1
+++ b/CreateSurfaceWindowsImage.ps1
@@ -800,7 +800,7 @@ Function Download-LatestUpdates
         
         $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress
         $body = @{ updateIDs = "[$post]" }
-        Invoke-WebRequest -Uri 'https://www.catalog.update.microsoft.com/DownloadDialog.aspx' -Method Post -Body $body | Select-Object -ExpandProperty Content
+        Invoke-WebRequest -Uri 'https://www.catalog.update.microsoft.com/DownloadDialog.aspx' -Method Post -Body $body -UseBasicParsing | Select-Object -ExpandProperty Content
     }
 
     $downloaddialogs = $global:KBGUID | ForEach-Object -Process $scriptblock
@@ -1157,7 +1157,7 @@ Function Get-LatestSurfaceEthernetDrivers
         
             $post = @{ size = 0; updateID = $guid; uidInfo = $guid } | ConvertTo-Json -Compress
             $body = @{ updateIDs = "[$post]" }
-            Invoke-WebRequest -Uri 'https://www.catalog.update.microsoft.com/DownloadDialog.aspx' -Method Post -Body $body | Select-Object -ExpandProperty Content
+            Invoke-WebRequest -Uri 'https://www.catalog.update.microsoft.com/DownloadDialog.aspx' -Method Post -Body $body -UseBasicParsing | Select-Object -ExpandProperty Content
         }
 
         $downloaddialogs = $global:KBGUID | ForEach-Object -Process $scriptblock


### PR DESCRIPTION
Fix for the
Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing  parameter and try again.